### PR TITLE
fix wrong eval of if statement because of wrong datatype.

### DIFF
--- a/PoShKeePass.psm1
+++ b/PoShKeePass.psm1
@@ -2019,7 +2019,7 @@ function New-KPConnection
             $CompositeKey.AddUserKey((New-Object KeepassLib.Keys.KcpPassword([System.Runtime.InteropServices.Marshal]::PtrToStringUni([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($MasterKey)))))
         }
 
-        if($KeyPath)
+        if($KeyPath -ne $false)
         {
             try
             {


### PR DESCRIPTION
even no $KeyPath File is used the if condition is true because of the string datatype. (Prints „wrong“ Warning)

[string]KeyPath = $false # is true

